### PR TITLE
fix: SonarQube warnings.

### DIFF
--- a/backpack/Cargo.toml
+++ b/backpack/Cargo.toml
@@ -10,10 +10,10 @@ clap = { version = "*", features = ["derive"] }
 colored = "3.0.0"
 which = "8.0.0"
 config = "0.15.4"
+xdg = "3.0.0"
 reqwest = { version = "0.12.9", default-features = false, features = ["blocking", "hickory-dns", "json", "rustls-tls"] }
 serde_json = "1.0.133"
 env_logger = "0.11.5"
-directories = "6.0.0"
 
 [[bin]]
 name = "github-rs"

--- a/backpack/src/lib.rs
+++ b/backpack/src/lib.rs
@@ -174,7 +174,7 @@ pub async fn update_repos(
                 );
                 std::process::exit(1);
             }
-        };
+        }
 
         count += 1;
         println!(

--- a/backpack/src/lib.rs
+++ b/backpack/src/lib.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use colored::Colorize;
 use config::Config;
-use directories::ProjectDirs;
 use octocrab::models::Repository;
 use octocrab::Octocrab;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
@@ -75,13 +74,14 @@ pub async fn get_token(token: String) -> Result<String, Box<dyn Error>> {
         return Ok(token);
     }
 
-    let base_path = ProjectDirs::from("org", "yonasBSD", "github-rs").expect("Get config path");
-    let config_path = base_path.config_dir();
+    let config_path = xdg::BaseDirectories::with_prefix("")
+        .get_config_home()
+        .unwrap();
 
     let m_token = match Config::builder()
         // Add in `./config/github-rs/config.toml`
         .add_source(config::File::with_name(
-            format!("{}/{}", config_path.display(), "/config").as_str(),
+            format!("{}/{}", config_path.display(), "github-rs/config").as_str(),
         ))
         // Add in settings from the environment (with a prefix of APP)
         // Eg.. `APP_DEBUG=1 ./target/app` would set the `debug` key

--- a/backpack/src/main.rs
+++ b/backpack/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::error::Error;
 
-use github_rs::*;
+use github_rs::{get_repos, get_token, update_repos, Cli};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
- remove semi-colon
- replace wildcard import with specific imports